### PR TITLE
An update is needed due to new Home Assistant requirements

### DIFF
--- a/homegear-rpi/config.json
+++ b/homegear-rpi/config.json
@@ -3,6 +3,7 @@
   "version": "0.70.4",
   "slug": "homegear-rpi",
   "description": "Homegear as a Hassio add-on for RaspberryPi",
+  "arch": ["amd64"],
   "startup": "services",
   "boot": "auto",
   "webui": "http://[HOST]:[PORT:2001]",


### PR DESCRIPTION
Don't really know if it's correct. Anyway here can see json as should be
https://developers.home-assistant.io/docs/en/hassio_addon_config.html
And arch must be a list of supported arch between: armhf, armv7, aarch64, amd64 and i386.