### PR TITLE
add armv7 arch parameter for rpi

### DIFF
--- a/homegear-rpi/config.json
+++ b/homegear-rpi/config.json
@@ -3,7 +3,7 @@
   "version": "0.70.4",
   "slug": "homegear-rpi",
   "description": "Homegear as a Hassio add-on for RaspberryPi",
-  "arch": ["amd64"],
+  "arch": ["armv7"],
   "startup": "services",
   "boot": "auto",
   "webui": "http://[HOST]:[PORT:2001]",


### PR DESCRIPTION
i've previously added a wrong arch. this (armv7) should be the right one for rpi system