### PR TITLE
edit runas user

### DIFF
--- a/homegear/script/run.sh
+++ b/homegear/script/run.sh
@@ -72,6 +72,9 @@ find /var/lib/homegear/ -type f -exec chmod 640 {} \;
 
 ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+echo "HOMEGEARUSER=root" > /etc/default/homegear
+echo "HOMEGEARGROUP=root" >> /etc/default/homegear
+
 service homegear start
 service homegear-management start
 service homegear-influxdb start


### PR DESCRIPTION
homegear needs to run as root to make /dev/tty* devices functional